### PR TITLE
Export NodeGraphicsObject and ConnectionGraphicsObject

### DIFF
--- a/src/ConnectionGraphicsObject.hpp
+++ b/src/ConnectionGraphicsObject.hpp
@@ -12,6 +12,7 @@
 #include "NodeData.hpp"
 #include "ConnectionState.hpp"
 #include "ConnectionID.hpp"
+#include "Export.hpp"
 
 class QGraphicsSceneMouseEvent;
 
@@ -21,7 +22,7 @@ namespace QtNodes
 class FlowScene;
 
 /// Graphic Object for connection.
-class ConnectionGraphicsObject
+class NODE_EDITOR_PUBLIC ConnectionGraphicsObject
   : public QGraphicsObject
 {
   Q_OBJECT

--- a/src/NodeGraphicsObject.hpp
+++ b/src/NodeGraphicsObject.hpp
@@ -6,6 +6,7 @@
 #include "NodeState.hpp"
 #include "NodeGeometry.hpp"
 #include "NodeIndex.hpp"
+#include "Export.hpp"
 
 class QGraphicsProxyWidget;
 
@@ -16,7 +17,7 @@ class FlowScene;
 
 /// Class reacts on GUI events, mouse clicks and
 /// forwards painting operation.
-class NodeGraphicsObject : public QGraphicsObject
+class NODE_EDITOR_PUBLIC NodeGraphicsObject : public QGraphicsObject
 {
   Q_OBJECT
 


### PR DESCRIPTION
(Otherwise Windows builds of external code that use methods of these
classes won't work.)